### PR TITLE
Add support for installing a properly named deb artifact

### DIFF
--- a/.github/workflows/callable_test-automation.yaml
+++ b/.github/workflows/callable_test-automation.yaml
@@ -261,10 +261,10 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx
-      - name: Download Pipeline sovrin.deb artifact
+      - name: Download Pipeline sovrin-deb artifact
         uses: actions/download-artifact@v3
         with:
-          name: sovrin.deb
+          name: sovrin-deb
           path: ./system/docker/node/
       - name: LS DEBUG
         run: ls ./system/docker/node/

--- a/system/docker/node/Dockerfile.ubuntu-2004
+++ b/system/docker/node/Dockerfile.ubuntu-2004
@@ -99,17 +99,18 @@ RUN if [ "${TOKEN_PLUGINS_INSTALL}" = "yes" ]; then \
                 #    sovrin=${SOVRIN_VERSION} \
                    sovtoken=${SOVTOKEN_VERSION} \
                    sovtokenfees=${SOVTOKENFEES_VERSION} \
-        && rm -rf /var/lib/apt/lists/*; \
-        # && pip install /sovtoken /sovtokenfees; \
+        && rm -rf /var/lib/apt/lists/* \
+        && pip install /sovtoken /sovtokenfees; \
     fi
-RUN pip install /sovtoken /sovtokenfees
 ARG SOVRIN_INSTALL
 ENV SOVRIN_INSTALL=$SOVRIN_INSTALL
 COPY . . 
 
 RUN echo "SOVRIN_INSTALL: ${SOVRIN_INSTALL}"
 RUN if [ "${SOVRIN_INSTALL}" = "yes" ]; then \
-    dpkg -i "sovrin.deb"; \
+        sovrin_package=$(find ./ -name "sovrin_*.deb" | head -n 1); \
+        echo "Installing ${sovrin_package} ..."; \
+        dpkg -i "${sovrin_package}"; \
     fi
 
 


### PR DESCRIPTION
- The sovrin artifact was being built with a hard coded filename that did not conform to the expected deb naming conventions.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>