### PR TITLE
Fix token plugin installation

### DIFF
--- a/system/docker/node/Dockerfile.ubuntu-2004
+++ b/system/docker/node/Dockerfile.ubuntu-2004
@@ -1,5 +1,5 @@
 #FROM jrei/systemd-ubuntu:20.04
-# 
+#
 # FROM systemd-ubuntu-20.04:latest
 FROM fauust/docker-systemd:ubuntu-20.04
 
@@ -80,7 +80,7 @@ RUN apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     # fix missing path to libursa
     && ln -s /usr/lib/ursa/libursa.so /usr/lib/libursa.so
- 
+
 ARG TOKEN_PLUGINS_INSTALL
 ENV TOKEN_PLUGINS_INSTALL=${TOKEN_PLUGINS_INSTALL}
 ARG SOVTOKEN_VERSION
@@ -99,12 +99,12 @@ RUN if [ "${TOKEN_PLUGINS_INSTALL}" = "yes" ]; then \
                 #    sovrin=${SOVRIN_VERSION} \
                    sovtoken=${SOVTOKEN_VERSION} \
                    sovtokenfees=${SOVTOKENFEES_VERSION} \
-        && rm -rf /var/lib/apt/lists/* \
-        && pip install /sovtoken /sovtokenfees; \
+        && rm -rf /var/lib/apt/lists/*; \
     fi
+
 ARG SOVRIN_INSTALL
 ENV SOVRIN_INSTALL=$SOVRIN_INSTALL
-COPY . . 
+COPY . .
 
 RUN echo "SOVRIN_INSTALL: ${SOVRIN_INSTALL}"
 RUN if [ "${SOVRIN_INSTALL}" = "yes" ]; then \
@@ -112,7 +112,6 @@ RUN if [ "${SOVRIN_INSTALL}" = "yes" ]; then \
         echo "Installing ${sovrin_package} ..."; \
         dpkg -i "${sovrin_package}"; \
     fi
-
 
 # network config
 RUN echo " " >> /etc/indy/indy_config.py \


### PR DESCRIPTION
- Now that the token plugin 20.04 deb packages are fixed, starting with 1.2.0~dev1674499579, the pip install step is no longer needed.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>