### PR TITLE
Fix automated tests

### DIFF
--- a/system/requirements-ubuntu-2004.txt
+++ b/system/requirements-ubuntu-2004.txt
@@ -3,6 +3,7 @@ pytest-asyncio==0.10.0
 base58==1.0.0
 testinfra==1.14.1
 python3-indy==1.16.0
+requests==2.29.0
 docker==3.7.0
 more-itertools==8.10.0
 async_generator


### PR DESCRIPTION
- Pin requests 2.29.0 which is the most recent version that still works with the docker 3.7.0 module.