### PR TITLE
Update Dockerfile for build image.

### DIFF
--- a/system/docker/node/Dockerfile.node
+++ b/system/docker/node/Dockerfile.node
@@ -29,7 +29,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61 \
 
 # Sovrin Artifactory
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3BC8C2DD662F1C45 \
-    && echo "deb https://sovrin.jfrog.io/artifactory/deb focal dev rc master" >> /etc/apt/sources.list
+    && echo "deb https://sovrin.jfrog.io/artifactory/deb focal dev rc stable" >> /etc/apt/sources.list
 
 COPY * /
 

--- a/system_payments_only/docker/node/Dockerfile.ubuntu-2004
+++ b/system_payments_only/docker/node/Dockerfile.ubuntu-2004
@@ -92,7 +92,7 @@ RUN if [ "${TOKEN_PLUGINS_INSTALL}" = "yes" ]; then \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3BC8C2DD662F1C45 \
         # && rm /etc/apt/sources.list.d/sovrin* \
         # && add-apt-repository "deb https://sovrin.jfrog.io/artifactory/deb focal ${SOVTOKEN_REPO_COMPONENT}" \
-        && echo "deb https://sovrin.jfrog.io/artifactory/deb focal dev rc master" >> /etc/apt/sources.list \
+        && echo "deb https://sovrin.jfrog.io/artifactory/deb focal dev rc stable" >> /etc/apt/sources.list \
         && apt-get update && apt-get install -y \
                 # ToDo:
                 #   - Need an Ubuntu 20.04 SOVRIN Build.


### PR DESCRIPTION
- Sovrin release packages are published to `stable`, not `master`.