### PR TITLE
Remove indy-sdk-tests from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,15 +27,6 @@ updates:
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
-    directory: "/system/indy-sdk-tests"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-
-  # Maintain dependencies for docker
-  - package-ecosystem: "docker"
     directory: "/system/docker/client"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pr removes a reference to indy-sdk-tests I missed from dependabot.