### PR TITLE
Update repository references for Ursa.

### DIFF
--- a/system/docker/node/Dockerfile.node
+++ b/system/docker/node/Dockerfile.node
@@ -21,6 +21,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
 # Hyperledger Artifactory
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61 \
     && echo "deb https://hyperledger.jfrog.io/artifactory/indy focal dev rc stable" >> /etc/apt/sources.list \
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy bionic master" >> /etc/apt/sources.list \
     && printf '%s\n%s\n%s\n' 'Package: *' 'Pin: origin hyperledger.jfrog.io' 'Pin-Priority: 1001' >> /etc/apt/preferences
 
 COPY * /


### PR DESCRIPTION
- The Ursa package has been migrated to the Hyperledger repository.  The Sovrin repositories have been deprecated.
  - New location: https://hyperledger.jfrog.io/ui/native/indy/pool/bionic/master/u/ursa/
  - Previous location: https://repo.sovrin.org/deb/pool/bionic/master/u/ursa/